### PR TITLE
Hotfix - Husky script and storybook styles

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,7 @@
 import type { Preview } from '@storybook/react';
 
+import '@/styles/main.scss';
+
 const preview: Preview = {
 	parameters: {
 		layout: 'fullscreen',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "plop": "node --experimental-specifier-resolution=node --no-warnings --loader=ts-node/esm .scripts/plop/index.ts",
-    "postinstall": "npm install -D husky"
+    "prepare": "husky"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
Fix husky script with the default one provided on first install and import missing main styles into storybook.